### PR TITLE
Issue #23692 Fixed build

### DIFF
--- a/appserver/admin/template/pom.xml
+++ b/appserver/admin/template/pom.xml
@@ -88,6 +88,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>create-artifact</id>
                         <phase>process-resources</phase>
                         <goals>
                             <goal>single</goal>

--- a/appserver/distributions/glassfish-common/pom.xml
+++ b/appserver/distributions/glassfish-common/pom.xml
@@ -87,7 +87,11 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>default-single</id>
+                        <id>create-artifact</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/appserver/distributions/pom.xml
+++ b/appserver/distributions/pom.xml
@@ -154,25 +154,15 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>default-single</id>
-                            <phase>process-resources</phase>
-                            <goals>
-                                <goal>single</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                     <configuration>
                         <descriptors>
-                            <descriptor>${basedir}/src/main/assembly/${project.artifactId}.xml</descriptor>
+                            <descriptor>src/main/assembly/${project.artifactId}.xml</descriptor>
                         </descriptors>
                         <ignoreMissingDescriptor>false</ignoreMissingDescriptor>
                         <finalName>${stage.dir.name}</finalName>
                         <attach>false</attach>
                         <appendAssemblyId>false</appendAssemblyId>
                         <useProjectArtifact>false</useProjectArtifact>
-                        <ignoreMissingDescriptor>true</ignoreMissingDescriptor>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/nucleus/distributions/nucleus-common/pom.xml
+++ b/nucleus/distributions/nucleus-common/pom.xml
@@ -37,7 +37,11 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>process-step3</id>
+                        <id>create-artifact</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/nucleus/distributions/pom.xml
+++ b/nucleus/distributions/pom.xml
@@ -130,25 +130,15 @@
 
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>default-single</id>
-                            <phase>process-resources</phase>
-                            <goals>
-                                <goal>single</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                     <configuration>
                         <descriptors>
-                            <descriptor>${basedir}/src/main/assembly/${project.artifactId}.xml</descriptor>
+                            <descriptor>src/main/assembly/${project.artifactId}.xml</descriptor>
                         </descriptors>
                         <ignoreMissingDescriptor>false</ignoreMissingDescriptor>
                         <finalName>${stage.dir.name}</finalName>
                         <attach>false</attach>
                         <appendAssemblyId>false</appendAssemblyId>
                         <useProjectArtifact>false</useProjectArtifact>
-                        <ignoreMissingDescriptor>true</ignoreMissingDescriptor>
                     </configuration>
                 </plugin>
 

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -961,7 +961,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
@@ -980,7 +979,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>


### PR DESCRIPTION
- default-single is brought by maven if we configured plugin execution in pluginManagment
  but not in plugins AND is mentioned in any parent (even if inherited=false)
- so I removed the execution and left it's configuration
- now the default-single is used just in 4 cases:
  atomic, web, glassfish, nucleus-new
- explicit execution is just in cases when we need the assembly sooner (usually
  for the glassfishbuild-maven-plugin)

Signed-off-by: David Matějček <dmatej@seznam.cz>
